### PR TITLE
LEO-9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </distributionManagement>
 
     <properties>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <jdbc.test.driver>org.h2.Driver</jdbc.test.driver>
@@ -78,9 +78,9 @@
             <version>3.5.6</version>
         </dependency>
         <dependency>
-            <groupId>net.sf.jsqlparser</groupId>
+            <groupId>com.github.jsqlparser</groupId>
             <artifactId>jsqlparser</artifactId>
-            <version>0.7.0</version>
+            <version>5.3</version>
         </dependency>
     </dependencies>
     <build>
@@ -166,7 +166,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.9</version>
                 <configuration>
-                    <argLine>-Xms1024m -Xmx1024m -XX:MaxPermSize=256m -ea -Dfile.encoding=UTF-8</argLine>
+                    <argLine>-Xms1024m -Xmx1024m -ea -Dfile.encoding=UTF-8</argLine>
                 </configuration>
             </plugin>
             <!-- sql插件 -->

--- a/src/main/java/com/rookiefly/open/shardbatis/converter/AbstractSqlConverter.java
+++ b/src/main/java/com/rookiefly/open/shardbatis/converter/AbstractSqlConverter.java
@@ -22,9 +22,10 @@ public abstract class AbstractSqlConverter implements SqlConverter {
      * @return String
      */
     protected String doDeParse(Statement statement) {
-        StatementDeParser deParser = new StatementDeParser(new StringBuffer());
+        StringBuilder buffer = new StringBuilder();
+        StatementDeParser deParser = new StatementDeParser(buffer);
         statement.accept(deParser);
-        return deParser.getBuffer().toString();
+        return buffer.toString();
     }
 
     /**

--- a/src/main/java/com/rookiefly/open/shardbatis/converter/SelectSqlConverter.java
+++ b/src/main/java/com/rookiefly/open/shardbatis/converter/SelectSqlConverter.java
@@ -1,73 +1,14 @@
 package com.rookiefly.open.shardbatis.converter;
 
-import net.sf.jsqlparser.expression.AllComparisonExpression;
 import net.sf.jsqlparser.expression.AnyComparisonExpression;
-import net.sf.jsqlparser.expression.BinaryExpression;
-import net.sf.jsqlparser.expression.CaseExpression;
-import net.sf.jsqlparser.expression.DateValue;
-import net.sf.jsqlparser.expression.DoubleValue;
-import net.sf.jsqlparser.expression.Expression;
-import net.sf.jsqlparser.expression.ExpressionVisitor;
-import net.sf.jsqlparser.expression.Function;
-import net.sf.jsqlparser.expression.InverseExpression;
-import net.sf.jsqlparser.expression.JdbcParameter;
-import net.sf.jsqlparser.expression.LongValue;
-import net.sf.jsqlparser.expression.NullValue;
-import net.sf.jsqlparser.expression.Parenthesis;
-import net.sf.jsqlparser.expression.StringValue;
-import net.sf.jsqlparser.expression.TimeValue;
-import net.sf.jsqlparser.expression.TimestampValue;
-import net.sf.jsqlparser.expression.WhenClause;
-import net.sf.jsqlparser.expression.operators.arithmetic.Addition;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseAnd;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseOr;
-import net.sf.jsqlparser.expression.operators.arithmetic.BitwiseXor;
-import net.sf.jsqlparser.expression.operators.arithmetic.Concat;
-import net.sf.jsqlparser.expression.operators.arithmetic.Division;
-import net.sf.jsqlparser.expression.operators.arithmetic.Multiplication;
-import net.sf.jsqlparser.expression.operators.arithmetic.Subtraction;
-import net.sf.jsqlparser.expression.operators.conditional.AndExpression;
-import net.sf.jsqlparser.expression.operators.conditional.OrExpression;
-import net.sf.jsqlparser.expression.operators.relational.Between;
-import net.sf.jsqlparser.expression.operators.relational.EqualsTo;
-import net.sf.jsqlparser.expression.operators.relational.ExistsExpression;
-import net.sf.jsqlparser.expression.operators.relational.ExpressionList;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThan;
-import net.sf.jsqlparser.expression.operators.relational.GreaterThanEquals;
-import net.sf.jsqlparser.expression.operators.relational.InExpression;
-import net.sf.jsqlparser.expression.operators.relational.IsNullExpression;
-import net.sf.jsqlparser.expression.operators.relational.ItemsListVisitor;
-import net.sf.jsqlparser.expression.operators.relational.LikeExpression;
-import net.sf.jsqlparser.expression.operators.relational.Matches;
-import net.sf.jsqlparser.expression.operators.relational.MinorThan;
-import net.sf.jsqlparser.expression.operators.relational.MinorThanEquals;
-import net.sf.jsqlparser.expression.operators.relational.NotEqualsTo;
-import net.sf.jsqlparser.schema.Column;
+import net.sf.jsqlparser.expression.ExpressionVisitorAdapter;
 import net.sf.jsqlparser.schema.Table;
 import net.sf.jsqlparser.statement.Statement;
-import net.sf.jsqlparser.statement.select.FromItemVisitor;
-import net.sf.jsqlparser.statement.select.Join;
-import net.sf.jsqlparser.statement.select.PlainSelect;
-import net.sf.jsqlparser.statement.select.Select;
-import net.sf.jsqlparser.statement.select.SelectVisitor;
-import net.sf.jsqlparser.statement.select.SubJoin;
-import net.sf.jsqlparser.statement.select.SubSelect;
-import net.sf.jsqlparser.statement.select.Union;
+import net.sf.jsqlparser.statement.select.*;
+import net.sf.jsqlparser.statement.piped.FromQuery;
 
-import java.util.Iterator;
-
-/**
- * @author sean.he
- */
 public class SelectSqlConverter extends AbstractSqlConverter {
 
-    /*
-     * (non-Javadoc)
-     *
-     * @see
-     * com.google.code.shardbatis.converter.AbstractSqlConverter#doConvert(net
-     * .sf.jsqlparser.statement.Statement, java.lang.Object, java.lang.String)
-     */
     @Override
     protected Statement doConvert(Statement statement, final Object params,
                                   final String mapperId) {
@@ -76,279 +17,104 @@ public class SelectSqlConverter extends AbstractSqlConverter {
                     "The argument statement must is instance of Select.");
         }
         TableNameModifier modifier = new TableNameModifier(params, mapperId);
-        ((Select) statement).getSelectBody().accept(modifier);
+        Select select = (Select) statement;
+        select.accept((SelectVisitor<Void>) modifier, null);
         return statement;
     }
 
-    private class TableNameModifier implements SelectVisitor, FromItemVisitor,
-            ExpressionVisitor, ItemsListVisitor {
-        private Object params;
-        private String mapperId;
+    private class TableNameModifier extends ExpressionVisitorAdapter<Void>
+            implements SelectVisitor<Void>, FromItemVisitor<Void> {
+
+        private final Object params;
+        private final String mapperId;
 
         TableNameModifier(Object params, String mapperId) {
             this.params = params;
             this.mapperId = mapperId;
+            this.setSelectVisitor(this);
         }
 
-        @Override
-        @SuppressWarnings("unchecked")
-        public void visit(PlainSelect plainSelect) {
-            plainSelect.getFromItem().accept(this);
+        // Resolve conflicting no-arg defaults from both interfaces
+        @Override public void visit(PlainSelect ps) { visit(ps, null); }
+        @Override public void visit(SetOperationList sol) { visit(sol, null); }
+        @Override public void visit(ParenthesedSelect ps) { visit(ps, null); }
+        @Override public void visit(Values v) { visit(v, null); }
+        @Override public void visit(LateralSubSelect l) { visit(l, null); }
+        @Override public void visit(TableStatement ts) { visit(ts, null); }
 
+        // ========== ExpressionVisitor: handle ALL/ANY subqueries ==========
+        @Override
+        public <S> Void visit(AnyComparisonExpression expr, S context) {
+            expr.getSelect().accept((SelectVisitor<Void>) this, context);
+            return null;
+        }
+
+        // ========== Shared SelectVisitor/FromItemVisitor methods ==========
+
+        @Override
+        public <S> Void visit(PlainSelect plainSelect, S context) {
+            if (plainSelect.getFromItem() != null) {
+                plainSelect.getFromItem().accept(this, context);
+            }
             if (plainSelect.getJoins() != null) {
-                for (Iterator joinsIt = plainSelect.getJoins().iterator(); joinsIt
-                        .hasNext(); ) {
-                    Join join = (Join) joinsIt.next();
-                    join.getRightItem().accept(this);
+                for (Join join : plainSelect.getJoins()) {
+                    join.getFromItem().accept(this, context);
                 }
             }
             if (plainSelect.getWhere() != null) {
-                plainSelect.getWhere().accept(this);
+                plainSelect.getWhere().accept(this, context);
             }
-
+            return null;
         }
 
         @Override
-        @SuppressWarnings("unchecked")
-        public void visit(Union union) {
-            for (Iterator iter = union.getPlainSelects().iterator(); iter
-                    .hasNext(); ) {
-                PlainSelect plainSelect = (PlainSelect) iter.next();
-                visit(plainSelect);
+        public <S> Void visit(SetOperationList setOpList, S context) {
+            for (Select sel : setOpList.getSelects()) {
+                sel.accept((SelectVisitor<Void>) this, context);
             }
+            return null;
         }
 
         @Override
-        public void visit(Table tableName) {
+        public <S> Void visit(ParenthesedSelect parenthesedSelect, S context) {
+            parenthesedSelect.getSelect().accept((SelectVisitor<Void>) this, context);
+            return null;
+        }
+
+        @Override
+        public <S> Void visit(Values values, S context) { return null; }
+        @Override
+        public <S> Void visit(LateralSubSelect lss, S context) { return null; }
+        @Override
+        public <S> Void visit(TableStatement ts, S context) { return null; }
+        @Override
+        public <S> Void visit(FromQuery fq, S context) { return null; }
+
+        // ========== SelectVisitor only ==========
+        @Override
+        public <S> Void visit(WithItem<?> wi, S context) { return null; }
+
+        // ========== FromItemVisitor only ==========
+        @Override
+        public <S> Void visit(Table tableName, S context) {
             String table = tableName.getName();
             table = convertTableName(table, params, mapperId);
-            // convert table name
             tableName.setName(table);
+            return null;
         }
 
         @Override
-        public void visit(SubSelect subSelect) {
-            subSelect.getSelectBody().accept(this);
-        }
-
-        @Override
-        public void visit(Addition addition) {
-            visitBinaryExpression(addition);
-        }
-
-        @Override
-        public void visit(AndExpression andExpression) {
-            visitBinaryExpression(andExpression);
-        }
-
-        @Override
-        public void visit(Between between) {
-            between.getLeftExpression().accept(this);
-            between.getBetweenExpressionStart().accept(this);
-            between.getBetweenExpressionEnd().accept(this);
-        }
-
-        @Override
-        public void visit(Column tableColumn) {
-        }
-
-        @Override
-        public void visit(Division division) {
-            visitBinaryExpression(division);
-        }
-
-        @Override
-        public void visit(DoubleValue doubleValue) {
-        }
-
-        @Override
-        public void visit(EqualsTo equalsTo) {
-            visitBinaryExpression(equalsTo);
-        }
-
-        @Override
-        public void visit(Function function) {
-        }
-
-        @Override
-        public void visit(GreaterThan greaterThan) {
-            visitBinaryExpression(greaterThan);
-        }
-
-        @Override
-        public void visit(GreaterThanEquals greaterThanEquals) {
-            visitBinaryExpression(greaterThanEquals);
-        }
-
-        @Override
-        public void visit(InExpression inExpression) {
-            inExpression.getLeftExpression().accept(this);
-            inExpression.getItemsList().accept(this);
-        }
-
-        @Override
-        public void visit(InverseExpression inverseExpression) {
-            inverseExpression.getExpression().accept(this);
-        }
-
-        @Override
-        public void visit(IsNullExpression isNullExpression) {
-        }
-
-        @Override
-        public void visit(JdbcParameter jdbcParameter) {
-        }
-
-        @Override
-        public void visit(LikeExpression likeExpression) {
-            visitBinaryExpression(likeExpression);
-        }
-
-        @Override
-        public void visit(ExistsExpression existsExpression) {
-            existsExpression.getRightExpression().accept(this);
-        }
-
-        @Override
-        public void visit(LongValue longValue) {
-        }
-
-        @Override
-        public void visit(MinorThan minorThan) {
-            visitBinaryExpression(minorThan);
-        }
-
-        @Override
-        public void visit(MinorThanEquals minorThanEquals) {
-            visitBinaryExpression(minorThanEquals);
-        }
-
-        @Override
-        public void visit(Multiplication multiplication) {
-            visitBinaryExpression(multiplication);
-        }
-
-        @Override
-        public void visit(NotEqualsTo notEqualsTo) {
-            visitBinaryExpression(notEqualsTo);
-        }
-
-        @Override
-        public void visit(NullValue nullValue) {
-        }
-
-        @Override
-        public void visit(OrExpression orExpression) {
-            visitBinaryExpression(orExpression);
-        }
-
-        @Override
-        public void visit(Parenthesis parenthesis) {
-            parenthesis.getExpression().accept(this);
-        }
-
-        @Override
-        public void visit(Subtraction subtraction) {
-            visitBinaryExpression(subtraction);
-        }
-
-        public void visitBinaryExpression(BinaryExpression binaryExpression) {
-            binaryExpression.getLeftExpression().accept(this);
-            binaryExpression.getRightExpression().accept(this);
-        }
-
-        @Override
-        @SuppressWarnings("unchecked")
-        public void visit(ExpressionList expressionList) {
-            for (Iterator iter = expressionList.getExpressions().iterator(); iter
-                    .hasNext(); ) {
-                Expression expression = (Expression) iter.next();
-                expression.accept(this);
+        public <S> Void visit(ParenthesedFromItem pfi, S context) {
+            pfi.getFromItem().accept(this, context);
+            if (pfi.getJoins() != null) {
+                for (Join join : pfi.getJoins()) {
+                    join.getFromItem().accept(this, context);
+                }
             }
-
+            return null;
         }
 
         @Override
-        public void visit(DateValue dateValue) {
-        }
-
-        @Override
-        public void visit(TimestampValue timestampValue) {
-        }
-
-        @Override
-        public void visit(TimeValue timeValue) {
-        }
-
-        /*
-         * (non-Javadoc)
-         *
-         * @see
-         * net.sf.jsqlparser.expression.ExpressionVisitor#visit(net.sf.jsqlparser
-         * .expression.CaseExpression)
-         */
-        @Override
-        public void visit(CaseExpression caseExpression) {
-        }
-
-        /*
-         * (non-Javadoc)
-         *
-         * @see
-         * net.sf.jsqlparser.expression.ExpressionVisitor#visit(net.sf.jsqlparser
-         * .expression.WhenClause)
-         */
-        @Override
-        public void visit(WhenClause whenClause) {
-        }
-
-        @Override
-        public void visit(AllComparisonExpression allComparisonExpression) {
-            allComparisonExpression.GetSubSelect().getSelectBody().accept(this);
-        }
-
-        @Override
-        public void visit(AnyComparisonExpression anyComparisonExpression) {
-            anyComparisonExpression.GetSubSelect().getSelectBody().accept(this);
-        }
-
-        @Override
-        public void visit(SubJoin subjoin) {
-            subjoin.getLeft().accept(this);
-            subjoin.getJoin().getRightItem().accept(this);
-        }
-
-        @Override
-        public void visit(Concat concat) {
-            visitBinaryExpression(concat);
-        }
-
-        @Override
-        public void visit(Matches matches) {
-            visitBinaryExpression(matches);
-
-        }
-
-        @Override
-        public void visit(BitwiseAnd bitwiseAnd) {
-            visitBinaryExpression(bitwiseAnd);
-
-        }
-
-        @Override
-        public void visit(BitwiseOr bitwiseOr) {
-            visitBinaryExpression(bitwiseOr);
-
-        }
-
-        @Override
-        public void visit(BitwiseXor bitwiseXor) {
-            visitBinaryExpression(bitwiseXor);
-        }
-
-        @Override
-        public void visit(StringValue stringValue) {
-        }
+        public <S> Void visit(TableFunction tf, S context) { return null; }
     }
-
 }

--- a/src/main/java/com/rookiefly/open/shardbatis/converter/SqlConverterFactory.java
+++ b/src/main/java/com/rookiefly/open/shardbatis/converter/SqlConverterFactory.java
@@ -2,16 +2,16 @@ package com.rookiefly.open.shardbatis.converter;
 
 import com.rookiefly.open.shardbatis.ShardException;
 import net.sf.jsqlparser.JSQLParserException;
-import net.sf.jsqlparser.parser.CCJSqlParserManager;
+import net.sf.jsqlparser.parser.CCJSqlParserUtil;
 import net.sf.jsqlparser.statement.Statement;
 import net.sf.jsqlparser.statement.delete.Delete;
 import net.sf.jsqlparser.statement.insert.Insert;
-import net.sf.jsqlparser.statement.select.Select;
+import net.sf.jsqlparser.statement.select.PlainSelect;
+import net.sf.jsqlparser.statement.select.SetOperationList;
 import net.sf.jsqlparser.statement.update.Update;
 import org.apache.ibatis.logging.Log;
 import org.apache.ibatis.logging.LogFactory;
 
-import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -34,16 +34,15 @@ public class SqlConverterFactory {
     }
 
     private Map<String, SqlConverter> converterMap;
-    private CCJSqlParserManager pm;
 
     private SqlConverterFactory() {
         converterMap = new HashMap<String, SqlConverter>();
-        pm = new CCJSqlParserManager();
         register();
     }
 
     private void register() {
-        converterMap.put(Select.class.getName(), new SelectSqlConverter());
+        converterMap.put(PlainSelect.class.getName(), new SelectSqlConverter());
+        converterMap.put(SetOperationList.class.getName(), new SelectSqlConverter());
         converterMap.put(Insert.class.getName(), new InsertSqlConverter());
         converterMap.put(Update.class.getName(), new UpdateSqlConverter());
         converterMap.put(Delete.class.getName(), new DeleteSqlConverter());
@@ -62,7 +61,7 @@ public class SqlConverterFactory {
             throws ShardException {
         Statement statement = null;
         try {
-            statement = pm.parse(new StringReader(sql));
+            statement = CCJSqlParserUtil.parse(sql);
         } catch (JSQLParserException e) {
             log.error(e.getMessage(), e);
             throw new ShardException(e);

--- a/src/test/resources/sql_ret.txt
+++ b/src/test/resources/sql_ret.txt
@@ -3,26 +3,26 @@ SELECT * FROM test_table1_xx WHERE col_1 = '123'
 SELECT * FROM test_table1_xx WHERE col_1 = '123' AND col_2 = 8
 SELECT * FROM test_table1_xx WHERE col_1 = ?
 SELECT col_1, max(col_2) FROM test_table1_xx WHERE col_4 = 't1' GROUP BY col_1
-SELECT col_1, col_2, col_3 FROM test_table1_xx WHERE col_4 = 't1' ORDER BY col_1 ASC
-SELECT col_1, col_2, col_3 FROM test_table1_xx WHERE id IN (?, ?, ?, ?, ?, ?, ?, ?, ?) LIMIT ? OFFSET ?
-SELECT a.* FROM test_table1_xx AS a, test_table2_xx AS b WHERE a.id = b.id AND a.type = 'xxxx'
-SELECT a.col_1, a.col_2, a.col_3 FROM test_table1_xx AS a WHERE a.id IN (SELECT aid FROM test_table2_xx WHERE col_1 = 1 AND col_2 = ?) ORDER BY id DESC
-SELECT col_1, col_2 FROM test_table1_xx WHERE type IS NOT NULL AND col_3 IS NULL ORDER BY id ASC
+SELECT col_1, col_2, col_3 FROM test_table1_xx WHERE col_4 = 't1' ORDER BY col_1
+SELECT col_1, col_2, col_3 FROM test_table1_xx WHERE id IN (?, ?, ?, ?, ?, ?, ?, ?, ?) LIMIT ?, ?
+SELECT a.* FROM test_table1_xx a, test_table2_xx b WHERE a.id = b.id AND a.type = 'xxxx'
+SELECT a.col_1, a.col_2, a.col_3 FROM test_table1_xx a WHERE a.id IN (SELECT aid FROM test_table2_xx WHERE col_1 = 1 AND col_2 = ?) ORDER BY id DESC
+SELECT col_1, col_2 FROM test_table1_xx WHERE type IS NOT NULL AND col_3 IS NULL ORDER BY id
 SELECT count(*), col_1 FROM test_table2_xx GROUP BY col_1 HAVING count(*) > 1
-SELECT a.col_1, a.col_2, b.col_1 FROM test_table1_xx AS a, t_table AS b WHERE a.id = b.id
-INSERT INTO test_table1_xx(col_1, col_2, col_3, col_4) VALUES (?, ?, ?, ?)
+SELECT a.col_1, a.col_2, b.col_1 FROM test_table1_xx a, t_table b WHERE a.id = b.id
+INSERT INTO test_table1_xx (col_1, col_2, col_3, col_4) VALUES (?, ?, ?, ?)
 SELECT EMPLOYEEIDNO FROM test_table1_xx WHERE POSITION = 'Manager' AND SALARY > 60000 OR BENEFITS > 12000
 SELECT EMPLOYEEIDNO FROM test_table1_xx WHERE POSITION = 'Manager' AND (SALARY > 50000 OR BENEFIT > 10000)
 SELECT EMPLOYEEIDNO FROM test_table1_xx WHERE LASTNAME LIKE 'L%'
-SELECT DISTINCT SELLERID, OWNERLASTNAME, OWNERFIRSTNAME FROM test_table1_xx, test_table2_xx WHERE SELLERID = OWNERID ORDER BY OWNERLASTNAME ASC, OWNERFIRSTNAME ASC, OWNERID ASC
-SELECT OWNERFIRSTNAME, OWNERLASTNAME FROM test_table1_xx WHERE  EXISTS (SELECT * FROM test_table2_xx WHERE ITEM = ?)
-SELECT BUYERID, ITEM FROM test_table1_xx WHERE PRICE >=  ALL (SELECT PRICE FROM test_table2_xx)
-(SELECT BUYERID FROM test_table1_xx) UNION (SELECT BUYERID FROM test_table2_xx)
-SELECT OWNERID, 'is in both Orders & Antiques' FROM test_table1_xx AS a, test_table2_xx AS b WHERE a.OWNERID = b.BUYERID AND a.type IN (?, ?, ?)
-SELECT DISTINCT SELLERID, OWNERLASTNAME, OWNERFIRSTNAME FROM test_table1_xx, noconvert_table WHERE SELLERID = OWNERID ORDER BY OWNERLASTNAME ASC, OWNERFIRSTNAME ASC, OWNERID ASC
-SELECT a.* FROM test_table1_xx AS a, noconvert_table AS b WHERE a.SELLERID = b.OWNERID
-UPDATE test_table1_xx SET col_1=123, col_2=?, col_3=? WHERE col_4 = ?
-UPDATE test_table1_xx SET col_1=?, col_2=col_2 + 1 WHERE id IN (?, ?, ?, ?)
+SELECT DISTINCT SELLERID, OWNERLASTNAME, OWNERFIRSTNAME FROM test_table1_xx, test_table2_xx WHERE SELLERID = OWNERID ORDER BY OWNERLASTNAME, OWNERFIRSTNAME, OWNERID
+SELECT OWNERFIRSTNAME, OWNERLASTNAME FROM test_table1_xx WHERE EXISTS (SELECT * FROM test_table2_xx WHERE ITEM = ?)
+SELECT BUYERID, ITEM FROM test_table1_xx WHERE PRICE >= ALL(SELECT PRICE FROM test_table2_xx)
+SELECT BUYERID FROM test_table1_xx UNION SELECT BUYERID FROM test_table2_xx
+SELECT OWNERID, 'is in both Orders & Antiques' FROM test_table1_xx a, test_table2_xx b WHERE a.OWNERID = b.BUYERID AND a.type IN (?, ?, ?)
+SELECT DISTINCT SELLERID, OWNERLASTNAME, OWNERFIRSTNAME FROM test_table1_xx, noconvert_table WHERE SELLERID = OWNERID ORDER BY OWNERLASTNAME, OWNERFIRSTNAME, OWNERID
+SELECT a.* FROM test_table1_xx a, noconvert_table b WHERE a.SELLERID = b.OWNERID
+UPDATE test_table1_xx SET col_1 = 123, col_2 = ?, col_3 = ? WHERE col_4 = ?
+UPDATE test_table1_xx SET col_1 = ?, col_2 = col_2 + 1 WHERE id IN (?, ?, ?, ?)
 DELETE FROM test_table2_xx WHERE id IN (?, ?, ?, ?, ?, ?) AND col_1 IS NOT NULL
 INSERT INTO test_table1_xx VALUES (21, 01, 'Ottoman', ?, ?)
-INSERT INTO test_table1_xx(BUYERID, SELLERID, ITEM) VALUES (01, 21, ?)
+INSERT INTO test_table1_xx (BUYERID, SELLERID, ITEM) VALUES (01, 21, ?)


### PR DESCRIPTION
- Group ID: net.sf.jsqlparser → com.github.jsqlparser
- Java version: 1.8 → 11 (jsqlparser 5.x 最低要求)
- CCJSqlParserManager → CCJSqlParserUtil
- StatementDeParser: StringBuffer → StringBuilder
- SelectSqlConverter: 完全重写，适配 5.x visitor API
  - ExpressionVisitorAdapter + SelectVisitor + FromItemVisitor
  - SubSelect → ParenthesedSelect
  - SubJoin → ParenthesedFromItem
  - Union → SetOperationList
  - SelectBody 已移除，直接使用 PlainSelect
- SqlConverterFactory: 注册 PlainSelect/SetOperationList 替代 Select
- 更新测试期望输出适配 5.x 格式变化